### PR TITLE
Add AWS Bedrock bearer token support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,7 @@ OPENAI_API_KEY=sk-xxxxxxxxx
 ### AWS Bedrock  ###
 
 # AWS_REGION=us-east-1
+# AWS_BEARER_TOKEN_BEDROCK=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # AWS_ACCESS_KEY_ID=xxxxxxxxxxxxxxxxxxx
 # AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 

--- a/docs/self-hosting/environment-variables/model-provider.mdx
+++ b/docs/self-hosting/environment-variables/model-provider.mdx
@@ -152,6 +152,13 @@ If you need to use Azure OpenAI to provide model services, you can refer to the 
 - Default: -
 - Example: `AKIA5STVRLFSB4S9HWBR`
 
+### `AWS_BEARER_TOKEN_BEDROCK`
+
+- Type: Optional
+- Description: API key for Bedrock. When set, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are not required.
+- Default: -
+- Example: `abcde1234567890`
+
 ### `AWS_SECRET_ACCESS_KEY`
 
 - Type: Required

--- a/docs/self-hosting/environment-variables/model-provider.zh-CN.mdx
+++ b/docs/self-hosting/environment-variables/model-provider.zh-CN.mdx
@@ -151,6 +151,13 @@ LobeChat 在部署时提供了丰富的模型服务商相关的环境变量，�
 - 默认值：-
 - 示例：`AKIA5STVRLFSB4S9HWBR`
 
+### `AWS_BEARER_TOKEN_BEDROCK`
+
+- 类型：可选
+- 描述：Bedrock 的 API Key，设置后可不再配置 `AWS_ACCESS_KEY_ID` 和 `AWS_SECRET_ACCESS_KEY`
+- 默认值：-
+- 示例：`abcde1234567890`
+
 ### `AWS_SECRET_ACCESS_KEY`
 
 - 类型：必选

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@anthropic-ai/sdk": "^0.56.0",
     "@auth/core": "^0.38.0",
     "@aws-sdk/client-bedrock-runtime": "^3.848.0",
+    "@aws-sdk/token-providers": "^3.848.0",
     "@aws-sdk/client-s3": "^3.850.0",
     "@aws-sdk/s3-request-presigner": "^3.850.0",
     "@azure-rest/ai-inference": "1.0.0-beta.5",

--- a/src/config/llm.ts
+++ b/src/config/llm.ts
@@ -66,6 +66,7 @@ export const getLLMConfig = () => {
       AWS_ACCESS_KEY_ID: z.string().optional(),
       AWS_SECRET_ACCESS_KEY: z.string().optional(),
       AWS_SESSION_TOKEN: z.string().optional(),
+      AWS_BEARER_TOKEN_BEDROCK: z.string().optional(),
 
       ENABLED_WENXIN: z.boolean(),
       WENXIN_API_KEY: z.string().optional(),
@@ -237,6 +238,7 @@ export const getLLMConfig = () => {
       AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
       AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
       AWS_SESSION_TOKEN: process.env.AWS_SESSION_TOKEN,
+      AWS_BEARER_TOKEN_BEDROCK: process.env.AWS_BEARER_TOKEN_BEDROCK,
 
       ENABLED_WENXIN: !!process.env.WENXIN_API_KEY,
       WENXIN_API_KEY: process.env.WENXIN_API_KEY,

--- a/src/const/auth.ts
+++ b/src/const/auth.ts
@@ -36,6 +36,7 @@ export interface JWTPayload {
   awsRegion?: string;
   awsSecretAccessKey?: string;
   awsSessionToken?: string;
+  awsBearerToken?: string;
 
   cloudflareBaseURLOrAccountID?: string;
 

--- a/src/libs/model-runtime/bedrock/index.ts
+++ b/src/libs/model-runtime/bedrock/index.ts
@@ -3,6 +3,7 @@ import {
   InvokeModelCommand,
   InvokeModelWithResponseStreamCommand,
 } from '@aws-sdk/client-bedrock-runtime';
+import { fromStatic } from '@aws-sdk/token-providers';
 
 import { LobeRuntimeAI } from '../BaseAI';
 import { AgentRuntimeErrorType } from '../error';
@@ -61,6 +62,7 @@ export interface LobeBedrockAIParams {
   accessKeySecret?: string;
   region?: string;
   sessionToken?: string;
+  token?: string;
 }
 
 export class LobeBedrockAI implements LobeRuntimeAI {
@@ -68,18 +70,26 @@ export class LobeBedrockAI implements LobeRuntimeAI {
 
   region: string;
 
-  constructor({ region, accessKeyId, accessKeySecret, sessionToken }: LobeBedrockAIParams = {}) {
-    if (!(accessKeyId && accessKeySecret))
-      throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidBedrockCredentials);
+  constructor({ region, accessKeyId, accessKeySecret, sessionToken, token }: LobeBedrockAIParams = {}) {
     this.region = region ?? 'us-east-1';
-    this.client = new BedrockRuntimeClient({
-      credentials: {
-        accessKeyId: accessKeyId,
-        secretAccessKey: accessKeySecret,
-        sessionToken: sessionToken,
-      },
-      region: this.region,
-    });
+    if (token) {
+      this.client = new BedrockRuntimeClient({
+        authSchemePreference: ['smithy.api#httpBearerAuth'],
+        region: this.region,
+        token: fromStatic({ token: { token } }),
+      });
+    } else {
+      if (!(accessKeyId && accessKeySecret))
+        throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidBedrockCredentials);
+      this.client = new BedrockRuntimeClient({
+        credentials: {
+          accessKeyId: accessKeyId,
+          secretAccessKey: accessKeySecret,
+          sessionToken: sessionToken,
+        },
+        region: this.region,
+      });
+    }
   }
 
   async chat(payload: ChatStreamPayload, options?: ChatMethodOptions) {

--- a/src/server/modules/AgentRuntime/index.ts
+++ b/src/server/modules/AgentRuntime/index.ts
@@ -53,18 +53,29 @@ const getParamsFromPayload = (provider: string, payload: JWTPayload) => {
     }
 
     case ModelProvider.Bedrock: {
-      const { AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_REGION, AWS_SESSION_TOKEN } = llmConfig;
+      const {
+        AWS_SECRET_ACCESS_KEY,
+        AWS_ACCESS_KEY_ID,
+        AWS_REGION,
+        AWS_SESSION_TOKEN,
+        AWS_BEARER_TOKEN_BEDROCK,
+      } = llmConfig;
+
       let accessKeyId: string | undefined = AWS_ACCESS_KEY_ID;
       let accessKeySecret: string | undefined = AWS_SECRET_ACCESS_KEY;
-      let region = AWS_REGION;
       let sessionToken: string | undefined = AWS_SESSION_TOKEN;
-      // if the payload has the api key, use user
+      let region = AWS_REGION;
+      let bearerToken: string | undefined = AWS_BEARER_TOKEN_BEDROCK;
+
       if (payload.apiKey) {
-        accessKeyId = payload?.awsAccessKeyId;
-        accessKeySecret = payload?.awsSecretAccessKey;
-        sessionToken = payload?.awsSessionToken;
-        region = payload?.awsRegion;
+        bearerToken = payload.awsBearerToken || bearerToken;
+        accessKeyId = payload.awsAccessKeyId;
+        accessKeySecret = payload.awsSecretAccessKey;
+        sessionToken = payload.awsSessionToken;
+        region = payload.awsRegion;
       }
+
+      if (bearerToken) return { region, token: bearerToken };
       return { accessKeyId, accessKeySecret, region, sessionToken };
     }
 


### PR DESCRIPTION
## Summary
- support `AWS_BEARER_TOKEN_BEDROCK` for Bedrock
- update Bedrock runtime to accept bearer token
- document new environment variable in both languages
- update sample `.env.example`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH errors)*

------
https://chatgpt.com/codex/tasks/task_e_6883339adf58832bbb3bde64bab0b73b