### PR TITLE
Use Next.js standalone build for AWS CodePipeline deployments

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,8 +11,13 @@ phases:
     runtime-versions:
       nodejs: 22
     commands:
-      - echo "Installing Bun..."
-      - curl -fsSL https://bun.sh/install | bash
+      - |
+          if [ ! -x "$HOME/.bun/bin/bun" ]; then
+            echo "Installing Bun..."
+            curl -fsSL https://bun.sh/install | bash
+          else
+            echo "Using cached Bun at $HOME/.bun/bin/bun"
+          fi
       - export BUN_INSTALL="$HOME/.bun"
       - export PATH="$BUN_INSTALL/bin:$PATH"
 
@@ -36,19 +41,18 @@ phases:
 
 artifacts:
   files:
-    - .next/**/*
+    # deliver the standalone bundle, static assets and deployment scripts
+    - .next/standalone/**/*
+    - .next/static/**/*
     - public/**/*
     - package.json
     - bun.lockb
-    - node_modules/**/*
     - appspec.yml
     - deploy/**/*
   discard-paths: no
 
 cache:
   paths:
-    - '/root/.bun/**/*'
     - '~/.bun/**/*'
-    - '~/.cache/bun/**/*'
     - 'node_modules/**/*'
     - '.next/cache/**/*'

--- a/deploy/after_install.sh
+++ b/deploy/after_install.sh
@@ -31,8 +31,7 @@ chmod 600 .env
 chown -R lobechat:lobechat "$APP_DIR"
 
 # 轻量自检（不装依赖）
-[ -d ".next" ] || echo "WARN: .next missing (consider standalone or check artifacts)"
-[ -d "node_modules" ] || echo "WARN: node_modules missing (should be packaged in CodeBuild)"
+[ -d ".next/standalone" ] || echo "WARN: .next/standalone missing (check artifacts)"
 [ -f "package.json" ] || echo "WARN: package.json missing"
 
 log "after_install.sh done"

--- a/deploy/before_install.sh
+++ b/deploy/before_install.sh
@@ -56,16 +56,17 @@ WorkingDirectory=/opt/lobechat
 EnvironmentFile=-/opt/lobechat/.env
 Environment=NVM_DIR=/opt/lobechat/.nvm
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=PORT=3210
 
 ExecStart=/bin/bash -lc 'set -e; \
   export NVM_DIR=/opt/lobechat/.nvm; \
   [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"; \
   nvm install --lts >/dev/null 2>&1 || true; \
   nvm use --lts >/dev/null; \
-  export PATH="$(dirname "$(nvm which --lts)"):$PATH"; \
+  NODE_BIN="$(nvm which --lts)"; \
   cd /opt/lobechat; \
-  echo "Node=$(command -v node) $(node -v)"; \
-  exec node node_modules/next/dist/bin/next start -p 3210'
+  echo "Node=${NODE_BIN} $($NODE_BIN -v)"; \
+  exec "$NODE_BIN" .next/standalone/server.js'
 
 Restart=always
 RestartSec=5

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,6 @@ import type { NextConfig } from 'next';
 import ReactComponentName from 'react-scan/react-component-name/webpack';
 
 const isProd = process.env.NODE_ENV === 'production';
-const buildWithDocker = process.env.DOCKER === 'true';
 const isDesktop = process.env.NEXT_PUBLIC_IS_DESKTOP_APP === '1';
 const enableReactScan = !!process.env.REACT_SCAN_MONITOR_API_KEY;
 const isUsePglite = process.env.NEXT_PUBLIC_CLIENT_DB === 'pglite';
@@ -13,15 +12,10 @@ const isUsePglite = process.env.NEXT_PUBLIC_CLIENT_DB === 'pglite';
 // if you need to proxy the api endpoint to remote server
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH;
-const isStandaloneMode = buildWithDocker || isDesktop;
-
-const standaloneConfig: NextConfig = {
-  output: 'standalone',
-  outputFileTracingIncludes: { '*': ['public/**/*', '.next/static/**/*'] },
-};
 
 const nextConfig: NextConfig = {
-  ...(isStandaloneMode ? standaloneConfig : {}),
+  output: 'standalone',
+  outputFileTracingIncludes: { '*': ['public/**/*', '.next/static/**/*'] },
   basePath,
   compress: isProd,
   experimental: {


### PR DESCRIPTION
## Summary
- enable Next.js `standalone` output with static asset tracing
- streamline CodeBuild to cache Bun/node modules and ship only standalone bundle and scripts
- deploy with systemd unit that resolves Node via NVM and starts the standalone server

## Testing
- `bun test src/libs/clerk-auth/index.test.ts` *(fails: Cannot find module '@clerk/nextjs/server')*

------
https://chatgpt.com/codex/tasks/task_e_689acb2fe5d0832ba59bc640fa503a03